### PR TITLE
Blake -> Keccak

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 __pycache__
+shuffle_test_vectors.yaml

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-pyblake2==1.1.2
 bitstring==3.1.5
 pyyaml==3.13
+pysha3==1.0.2

--- a/sandbox.py
+++ b/sandbox.py
@@ -8,7 +8,7 @@ import yaml
 from src.shufflers import v2_1_spec
 from src.shufflers import reference
 from src.shufflers import bitsipper
-from src.utils import (blake, list_compare)
+from src.utils import list_compare, keccak256
 
 shufflers = {
     "v2.1_spec": v2_1_spec.shuffle,
@@ -58,8 +58,8 @@ def fuzz(max_list_size, shufflers):
         shuffler_a_func = pair[0][1]
         shuffler_b_name = pair[1][0]
         shuffler_b_func = pair[1][1]
-        a = shuffler_a_func(list(range(list_size)), blake(rand_bytes))
-        b = shuffler_b_func(list(range(list_size)), blake(rand_bytes))
+        a = shuffler_a_func(list(range(list_size)), keccak256(rand_bytes))
+        b = shuffler_b_func(list(range(list_size)), keccak256(rand_bytes))
         if not list_compare(a, b):
             print(("Inequality found! rand_string: {}, list_size: {}, " +
                    " shuffler_a: {}," + " shuffler_b: {}")
@@ -100,7 +100,7 @@ args = parser.parse_args()
 
 # this seed is know to cause inequality between the
 # v2.1 and v2.1_modified functions with a list size of 6.
-seed = blake(args.seed_str.encode())
+seed = keccak256(args.seed_str.encode())
 
 lst = list(range(args.list_size))
 
@@ -147,8 +147,8 @@ elif args.method == "test_vectors":
 
     for seed in seeds:
         for lst in lists:
-            blake_seed = blake(seed.encode()) if len(seed) > 0 else b""
-            output = shuffler(lst, blake_seed)
+            keccak_seed = keccak256(seed.encode()) if len(seed) > 0 else b""
+            output = shuffler(lst, keccak_seed)
             results.append({"seed": seed, "input": lst, "output": output})
 
     body = {

--- a/src/shufflers/bitsipper.py
+++ b/src/shufflers/bitsipper.py
@@ -5,7 +5,7 @@ minimum required bits for the specified range.
 """
 import math
 from bitstring import BitArray
-from src.utils import blake
+from src.utils import keccak256
 
 
 def shuffle(lst, seed):
@@ -23,11 +23,11 @@ def durstenfeld_shuffle(lst, rand_range):
 
 class ShuffleRng:
     def __init__(self, seed):
-        self.seed = BitArray(blake(seed))
+        self.seed = BitArray(keccak256(seed))
         self.seed_idx = 0
 
     def rehash_seed(self):
-        self.seed = BitArray(blake(self.seed.bytes))
+        self.seed = BitArray(keccak256(self.seed.bytes))
         self.seed_idx = 0
 
     def rand(self, num_bits):

--- a/src/shufflers/reference.py
+++ b/src/shufflers/reference.py
@@ -1,4 +1,4 @@
-from src.utils import blake
+from src.utils import keccak256
 
 NUM_RAND_BITS = 24
 RAND_MAX = 2**NUM_RAND_BITS - 1
@@ -19,11 +19,11 @@ def durstenfeld_shuffle(lst, rand_range):
 
 class ShuffleRng:
     def __init__(self, seed):
-        self.seed = blake(seed)
+        self.seed = keccak256(seed)
         self.seed_idx = 0
 
     def rehash_seed(self):
-        self.seed = blake(self.seed)
+        self.seed = keccak256(self.seed)
         self.seed_idx = 0
 
     def rand(self):
@@ -31,7 +31,7 @@ class ShuffleRng:
         first = self.seed_idx
         last = self.seed_idx + num_bytes
         if last > len(self.seed):
-            self.seed = blake(self.seed)
+            self.seed = keccak256(self.seed)
             self.seed_idx = 0
             first = self.seed_idx
             last = self.seed_idx + num_bytes

--- a/src/shufflers/v2_1_spec.py
+++ b/src/shufflers/v2_1_spec.py
@@ -1,6 +1,6 @@
-from src.utils import blake
+from src.utils import keccak256
 
-hash = blake
+shuffling_hash = keccak256
 
 
 def shuffle(values, seed):
@@ -23,7 +23,7 @@ def shuffle(values, seed):
     index = 0
     while index < values_count - 1:
         # Re-hash the `source` to obtain a new pattern of bytes.
-        source = hash(source)
+        source = shuffling_hash(source)
         # Iterate through the `source` bytes in 3-byte chunks.
         for position in range(0, 32 - (32 % rand_bytes), rand_bytes):
             # Determine the number of indices remaining in `values` and exit

--- a/src/utils.py
+++ b/src/utils.py
@@ -1,12 +1,8 @@
-try:
-    from hashlib import blake2b
-except Exception:
-    from pyblake2 import blake2b
+from sha3 import keccak_256
 
 
-def blake(x):
-    return blake2b(x).digest()[:32]
-
+def keccak256(x):
+    return keccak_256(x).digest()
 
 def list_compare(a, b):
     diff = [i for i, j in zip(a, b) if i != j]


### PR DESCRIPTION
# What?
* Replaced blake with 256-bit keccak
* ignored the output file from test_vectors
# How?
I just replaced the blake() function with a Keccak equivalent and moved the
pre-existing occurences on to it.

# Why
sigp/lighthouse#121, sigp/lighthouse#123 and partially sigp/lighthouse#111 +
sigp/lighthouse#109

# How did I verify that this works?
I ran sandbox.py with all of the method variants and saw results fairly similar to
vanilla repo state with no crashes. I'm no eth2 spec expert, so your input would be ideal.